### PR TITLE
Remove `md5` modifier from debug.tpl

### DIFF
--- a/libs/debug.tpl
+++ b/libs/debug.tpl
@@ -168,7 +168,7 @@
 {/capture}
 <script type="text/javascript">
     {$id = '__Smarty__'}
-    {if $display_mode}{$id = "$offset$template_name"|md5}{/if}
+    {if $display_mode}{$id = md5("$offset$template_name")}{/if}
     _smarty_console = window.open("", "console{$id}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");
     _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
     _smarty_console.document.close();


### PR DESCRIPTION
Replaced with a regular function call. 